### PR TITLE
Support empty values

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -79,7 +79,7 @@ func (ctx *parseCtx) peek() (string, error) {
 	return l, nil
 }
 
-var looksLikePropertyRe = regexp.MustCompile(`^[^:]+:.+$`)
+var looksLikePropertyRe = regexp.MustCompile(`^[^:]+:.*$`)
 
 func (ctx *parseCtx) nextProperty() (string, string, Parameters, error) {
 	l, err := ctx.next()
@@ -104,7 +104,7 @@ func (ctx *parseCtx) nextProperty() (string, string, Parameters, error) {
 
 	// name may contain parameters
 	var params = Parameters{}
-	paramslist := strings.Split(n, ";") 
+	paramslist := strings.Split(n, ";")
 	for i, v := range paramslist {
 		if i == 0 {
 			continue


### PR DESCRIPTION
	[..]
	BEGIN:VEVENT
	DTEND:20171012T190000Z
	LOCATION:
	END:VEVENT

Would have `dtend` have the value of `20171012T190000ZOCATION`, because
the `LOCATION:` does not have a value, and would be treated as a folded
line.

Common tools seem to generate these sort of iCal files, and the RFC
allows empty values: https://tools.ietf.org/html/rfc5545#section-3.1

	contentline   = name *(";" param ) ":" value CRLF
	value         = *VALUE-CHAR

`value` must consist of 0 or more `VALUE-CHAR`s.